### PR TITLE
Fix login error page

### DIFF
--- a/shopkeeper/web/templates/error.html
+++ b/shopkeeper/web/templates/error.html
@@ -1,0 +1,82 @@
+<!doctype html>
+<html>
+    <head>
+        <title>Error - Shopkeeper</title>
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+
+        <style>
+            html {
+                display: grid;
+                min-height: 100%;
+            }
+
+            body {
+                font-family:
+                    -apple-system,
+                    BlinkMacSystemFont,
+                    avenir next,
+                    avenir,
+                    segoe ui,
+                    helvetica neue,
+                    helvetica,
+                    Cantarell,
+                    Ubuntu,
+                    roboto,
+                    noto,
+                    arial,
+                    sans-serif;
+
+                background-color: hsl(240 10% 3.9%);
+                color: hsl(0 0% 98%);
+
+                display: flex;
+                align-items: center;
+                justify-content: center;
+            }
+
+            pre {
+                font-family:
+                    Menlo,
+                    Consolas,
+                    Monaco,
+                    Liberation Mono,
+                    Lucida Console,
+                    monospace;
+            }
+
+            a {
+                color: #0ea5e9;
+                transition: color 0.2s;
+                text-decoration: none;
+            }
+
+            a:hover,
+            a:hover:visited {
+                color: #7dd3fc;
+            }
+
+            a:visited {
+                color: #0ea5e9;
+            }
+
+            .error-container {
+                text-align: center;
+            }
+
+            .error-message {
+                padding: 1rem;
+                background-color: hsl(0 0% 10%);
+                border-radius: 0.5rem;
+            }
+        </style>
+    </head>
+    <body>
+        <div class="error-container">
+            <h1>An error occurred.</h1>
+            <div>
+                <pre class="error-message">{{ detail }}</pre>
+                <div>Maybe try <a href="/">going home</a> and attempt that again?</div>
+            </div>
+        </div>
+    </body>
+</html>

--- a/shopkeeper/web/templates/error.html
+++ b/shopkeeper/web/templates/error.html
@@ -34,16 +34,6 @@
                 justify-content: center;
             }
 
-            pre {
-                font-family:
-                    Menlo,
-                    Consolas,
-                    Monaco,
-                    Liberation Mono,
-                    Lucida Console,
-                    monospace;
-            }
-
             a {
                 color: #0ea5e9;
                 transition: color 0.2s;
@@ -67,6 +57,16 @@
                 padding: 1rem;
                 background-color: hsl(0 0% 10%);
                 border-radius: 0.5rem;
+                margin-bottom: 0.5rem;
+                text-align: left;
+
+                font-family:
+                    Menlo,
+                    Consolas,
+                    Monaco,
+                    Liberation Mono,
+                    Lucida Console,
+                    monospace;
             }
         </style>
     </head>
@@ -74,7 +74,7 @@
         <div class="error-container">
             <h1>An error occurred.</h1>
             <div>
-                <pre class="error-message">{{ detail }}</pre>
+                <div class="error-message">{{ detail }}</div>
                 <div>Maybe try <a href="/">going home</a> and attempt that again?</div>
             </div>
         </div>


### PR DESCRIPTION
# Changes

Add a handler for `HTTPException`s, returning a Jinja-templated page if the request has an explicit `Accept: text/html`. This'll result in users not getting a plain text JSON error page on a login error due to not being in the server.